### PR TITLE
Fix compatibility with 10.1

### DIFF
--- a/BuyEmAll/BuyEmAll.lua
+++ b/BuyEmAll/BuyEmAll.lua
@@ -73,10 +73,9 @@ function BuyEmAll:ItemIsUnique(itemIDOrLink)
 
     local tooltip = C_TooltipInfo.GetItemByID(itemIDOrLink);
     for _, line in ipairs(tooltip.lines) do
-        for _, arg in ipairs(line.args) do
-            if(arg.field == 'leftText' and arg.stringVal == 'Unique') then
-                return true;
-            end
+        TooltipUtil.SurfaceArgs(line);
+        if line.leftText == 'Unique' then
+            return true;
         end
     end
    


### PR DESCRIPTION
`TooltipUtil.SurfaceArgs` can be removed in 10.1